### PR TITLE
Remove JSX from index.js in addition to pragma

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,3 @@
-/**
- * @jsx React.DOM
- */
 'use strict';
 
 var React = require('react');
@@ -21,9 +18,14 @@ var component = React.createClass({
     };
 
     return (
-      <div className="progressbar-container" >
-        <div className="progressbar-progress" style={style}>{this.props.children}</div>
-      </div>
+      React.createElement(
+        'div',
+        { className: 'progressbar-container' },
+        React.createElement(
+          'div',
+          { className: 'progressbar-progress', style: style },
+          this.props.children
+      )
     );
   }
 });

--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ var component = React.createClass({
           'div',
           { className: 'progressbar-progress', style: style },
           this.props.children
+        )
       )
     );
   }


### PR DESCRIPTION
This is an opinionated change, but having the main `index.js` require a jsx compilation step is just unnecessary for such a small project. Either there should be a `dist` folder with a fully compiled version or, as I am proposing, just remove the JSX and use the compiled version for `index.js`.

Fixes #6.