### PR TITLE
use peerDependencies to prevent downloading a separated react

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "homepage": "https://github.com/paramaggarwal/react-progressbar",
   "author": "Param Aggarwal",
   "license": "MIT",
-  "dependencies": {
-    "react": "^0.14.3"
+  "peerDependencies": {
+    "react": "^15.0.1"
   }
 }


### PR DESCRIPTION
I tested it with react 15.0.1 and it still works perfectly.

Use peerDependencies here to prevent npm download another version of react which can cause a lot of problems.